### PR TITLE
AD-47 morse refactor home account discord api

### DIFF
--- a/sprint_1/ProjectDiscordStat/DiscordStat/Controllers/HomeController.cs
+++ b/sprint_1/ProjectDiscordStat/DiscordStat/Controllers/HomeController.cs
@@ -42,7 +42,7 @@ namespace DiscordStats.Controllers
         
 
         [Authorize(AuthenticationSchemes = "Discord")]
-        public  IActionResult Account()
+        public async Task<IActionResult> Account()
         {
             // Don't use the ViewBag!  Use a viewmodel instead.
             // The data in ClaimTypes can be mocked.  Will have to wait though for how to do that.
@@ -50,7 +50,7 @@ namespace DiscordStats.Controllers
             ViewBag.name = User.Claims.First(c => c.Type == ClaimTypes.Name).Value;
             string bearerToken = User.Claims.First(c => c.Type == ClaimTypes.Role).Value;
 
-            IEnumerable<Server>? servers = _discord.GetCurrentUserGuilds(bearerToken);
+            IEnumerable<Server>? servers = await _discord.GetCurrentUserGuilds(bearerToken);
 
             // Now we can inject a mock IDiscordService that fakes this method.  That will allow us to test
             // anything __after__ getting this list of servers, i.e. any logic that we perform with this data from

--- a/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Abstract/IDiscordService.cs
+++ b/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Abstract/IDiscordService.cs
@@ -1,0 +1,9 @@
+using DiscordStats.Models;
+
+namespace DiscordStats.DAL.Abstract
+{
+    public interface IDiscordService
+    {
+        public IEnumerable<Server>? GetCurrentUserGuilds(string bearerToken);
+    }
+}

--- a/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Abstract/IDiscordService.cs
+++ b/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Abstract/IDiscordService.cs
@@ -2,12 +2,6 @@ using DiscordStats.Models;
 
 namespace DiscordStats.DAL.Abstract
 {
-    // This is how we will allow mocking of GetJsonStringFromEndpoint.  It is a delegate method
-    // See: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/delegates/
-    // It is like a function pointer in C++, or how you can "pass a function" to a method like
-    // we've been doing in LINQ expressions all along
-    public delegate string SendRequest(string bearerToken, string uri);
-
     public interface IDiscordService
     {
         /// <summary>
@@ -15,7 +9,6 @@ namespace DiscordStats.DAL.Abstract
         /// </summary>
         /// <param name="bearerToken"></param>
         /// <returns></returns>
-        List<Server>? GetCurrentUserGuilds(string bearerToken);
-
+        Task<List<Server>?> GetCurrentUserGuilds(string bearerToken);
     }
 }

--- a/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Abstract/IDiscordService.cs
+++ b/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Abstract/IDiscordService.cs
@@ -2,8 +2,20 @@ using DiscordStats.Models;
 
 namespace DiscordStats.DAL.Abstract
 {
+    // This is how we will allow mocking of GetJsonStringFromEndpoint.  It is a delegate method
+    // See: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/delegates/
+    // It is like a function pointer in C++, or how you can "pass a function" to a method like
+    // we've been doing in LINQ expressions all along
+    public delegate string SendRequest(string bearerToken, string uri);
+
     public interface IDiscordService
     {
-        public IEnumerable<Server>? GetCurrentUserGuilds(string bearerToken);
+        /// <summary>
+        /// Get all servers for the user with the given token and the default message sender.
+        /// </summary>
+        /// <param name="bearerToken"></param>
+        /// <returns></returns>
+        List<Server>? GetCurrentUserGuilds(string bearerToken);
+
     }
 }

--- a/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Concrete/DiscordService.cs
+++ b/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Concrete/DiscordService.cs
@@ -1,21 +1,22 @@
 using DiscordStats.DAL.Abstract;
 using DiscordStats.Models;
-
-using System.Net.Http;
-using System.Net.Http.Headers;
-using Azure.Core;
 using System.Net;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace DiscordStats.DAL.Concrete
 {
+    // It would be nice to use constructor injection here to inject the ability to get a web request
+    // but that won't work in cases like this where we'd have to know the User and their bearer token
+    // before creating the service to inject.  Instead we use method parameter injection.
+
     public class DiscordService : IDiscordService
     {
-        public IEnumerable<Server>? GetCurrentUserGuilds(string bearerToken)
+        // This method wraps up the minimum functionality needed to make a request
+        // to an external dependency.  It cannot be unit tested, but we do need to fake it in
+        // order to test code that uses it, i.e. GetCurrentUserGuilds below
+        public static string GetJsonStringFromEndpoint(string bearerToken, string uri)
         {
-            var request = (HttpWebRequest)WebRequest.Create("https://discord.com/api/users/@me/guilds");
+            var request = (HttpWebRequest)WebRequest.Create(uri);
             request.Method = "GET";
             request.ContentType = "application/json";
             request.Headers.Add("Authorization", "Bearer " + bearerToken);
@@ -33,7 +34,24 @@ namespace DiscordStats.DAL.Concrete
                     }
                 }
             }
-            IEnumerable<Server>? servers = JsonConvert.DeserializeObject<List<Server>>(content);
+            return content;
+        }
+
+        // This is the method we can use from the controller, since the controller (usually) doesn't need to know
+        // anything about how this information is acquired
+        public List<Server>? GetCurrentUserGuilds(string bearerToken)
+        {
+            SendRequest sr = GetJsonStringFromEndpoint;
+            return GetCurrentUserGuilds( bearerToken, sr);
+        }
+
+        // But this is the method that actually does the work AND can have fake data injected via the delegate method
+        public List<Server>? GetCurrentUserGuilds(string bearerToken, SendRequest messageSender)
+        {
+            // Remember to handle errors here
+            string response = messageSender(bearerToken, "https://discord.com/api/users/@me/guilds");
+            // And here
+            List<Server>? servers = JsonConvert.DeserializeObject<List<Server>>(response);
             return servers;
         }
     }

--- a/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Concrete/DiscordService.cs
+++ b/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Concrete/DiscordService.cs
@@ -1,0 +1,40 @@
+using DiscordStats.DAL.Abstract;
+using DiscordStats.Models;
+
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Azure.Core;
+using System.Net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
+namespace DiscordStats.DAL.Concrete
+{
+    public class DiscordService : IDiscordService
+    {
+        public IEnumerable<Server>? GetCurrentUserGuilds(string bearerToken)
+        {
+            var request = (HttpWebRequest)WebRequest.Create("https://discord.com/api/users/@me/guilds");
+            request.Method = "GET";
+            request.ContentType = "application/json";
+            request.Headers.Add("Authorization", "Bearer " + bearerToken);
+            request.Headers.Add("Content-Type", "application/json");
+
+            var content = string.Empty;
+
+            using (var response = (HttpWebResponse)request.GetResponse())
+            {
+                using (var stream = response.GetResponseStream())
+                {
+                    using (var sr = new StreamReader(stream))
+                    {
+                        content = sr.ReadToEnd();
+                    }
+                }
+            }
+            IEnumerable<Server>? servers = JsonConvert.DeserializeObject<List<Server>>(content);
+            return servers;
+        }
+    }
+}

--- a/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Concrete/DiscordService.cs
+++ b/sprint_1/ProjectDiscordStat/DiscordStat/DAL/Concrete/DiscordService.cs
@@ -1,6 +1,7 @@
 using DiscordStats.DAL.Abstract;
 using DiscordStats.Models;
 using System.Net;
+using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
 
 namespace DiscordStats.DAL.Concrete
@@ -11,45 +12,50 @@ namespace DiscordStats.DAL.Concrete
 
     public class DiscordService : IDiscordService
     {
+        // Use constructor injection to get the http client factory, which we'll use to get an http client
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public DiscordService(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
         // This method wraps up the minimum functionality needed to make a request
         // to an external dependency.  It cannot be unit tested, but we do need to fake it in
         // order to test code that uses it, i.e. GetCurrentUserGuilds below
-        public static string GetJsonStringFromEndpoint(string bearerToken, string uri)
+        public async Task<string> GetJsonStringFromEndpoint(string bearerToken, string uri)
         {
-            var request = (HttpWebRequest)WebRequest.Create(uri);
-            request.Method = "GET";
-            request.ContentType = "application/json";
-            request.Headers.Add("Authorization", "Bearer " + bearerToken);
-            request.Headers.Add("Content-Type", "application/json");
-
-            var content = string.Empty;
-
-            using (var response = (HttpWebResponse)request.GetResponse())
-            {
-                using (var stream = response.GetResponseStream())
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri)
                 {
-                    using (var sr = new StreamReader(stream))
+                    Headers =
                     {
-                        content = sr.ReadToEnd();
+                        { HeaderNames.Accept, "application/json" },
+                        { HeaderNames.Authorization, "Bearer " + bearerToken},
+                        { HeaderNames.UserAgent, "DiscordStat" }
                     }
-                }
+                };
+            HttpClient httpClient = _httpClientFactory.CreateClient();
+            // Note this is the blocking version.  Would be better to use the Async version
+            HttpResponseMessage response = await httpClient.SendAsync(httpRequestMessage);
+
+            // This is only a minimal version; make sure to cover all your bases here
+            if(response.IsSuccessStatusCode)
+            {
+                // same here, this is blocking; use ReadAsStreamAsync instead
+                string responseText = await response.Content.ReadAsStringAsync();
+                return responseText;
             }
-            return content;
+            else
+            {
+                // What to do if failure? Should throw specific exceptions that explain what happened
+                throw new HttpRequestException();
+            }
         }
 
-        // This is the method we can use from the controller, since the controller (usually) doesn't need to know
-        // anything about how this information is acquired
-        public List<Server>? GetCurrentUserGuilds(string bearerToken)
-        {
-            SendRequest sr = GetJsonStringFromEndpoint;
-            return GetCurrentUserGuilds( bearerToken, sr);
-        }
-
-        // But this is the method that actually does the work AND can have fake data injected via the delegate method
-        public List<Server>? GetCurrentUserGuilds(string bearerToken, SendRequest messageSender)
+        public async Task<List<Server>?> GetCurrentUserGuilds(string bearerToken)
         {
             // Remember to handle errors here
-            string response = messageSender(bearerToken, "https://discord.com/api/users/@me/guilds");
+            string response = await GetJsonStringFromEndpoint(bearerToken, "https://discord.com/api/users/@me/guilds");
             // And here
             List<Server>? servers = JsonConvert.DeserializeObject<List<Server>>(response);
             return servers;

--- a/sprint_1/ProjectDiscordStat/DiscordStat/Program.cs
+++ b/sprint_1/ProjectDiscordStat/DiscordStat/Program.cs
@@ -13,13 +13,20 @@ using Microsoft.Extensions.Configuration;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authentication.OAuth.Claims;
+using DiscordStats.DAL.Abstract;
+using DiscordStats.DAL.Concrete;
 
 
 var builder = WebApplication.CreateBuilder(args);
-var connectionString = builder.Configuration.GetConnectionString("DiscordStatsContextConnection");builder.Services.AddDbContext<DiscordStatsIdentityDbContext>(options =>
+var connectionString = builder.Configuration.GetConnectionString("DiscordStatsContextConnection");
+builder.Services.AddDbContext<DiscordStatsIdentityDbContext>(options =>
     options.UseSqlServer(connectionString));builder.Services.AddDbContext<DiscordStatsContext>(options =>
     options.UseSqlServer(connectionString));builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
     .AddEntityFrameworkStores<DiscordStatsContext>();
+    
+// Add our repositories and services
+builder.Services.AddScoped<IDiscordService, DiscordService>();
+
 // Add services to the container.
 builder.Services.AddControllersWithViews();
 builder.Services.AddAuthentication(options =>

--- a/sprint_1/ProjectDiscordStat/DiscordStat/Program.cs
+++ b/sprint_1/ProjectDiscordStat/DiscordStat/Program.cs
@@ -18,12 +18,15 @@ using DiscordStats.DAL.Concrete;
 
 
 var builder = WebApplication.CreateBuilder(args);
+
 var connectionString = builder.Configuration.GetConnectionString("DiscordStatsContextConnection");
 builder.Services.AddDbContext<DiscordStatsIdentityDbContext>(options =>
     options.UseSqlServer(connectionString));builder.Services.AddDbContext<DiscordStatsContext>(options =>
     options.UseSqlServer(connectionString));builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
     .AddEntityFrameworkStores<DiscordStatsContext>();
     
+// Register an IHttpClientFactory to enable injection of HttpClients
+builder.Services.AddHttpClient();
 // Add our repositories and services
 builder.Services.AddScoped<IDiscordService, DiscordService>();
 

--- a/sprint_1/ProjectDiscordStat/DiscordStat/Views/Home/Account.cshtml
+++ b/sprint_1/ProjectDiscordStat/DiscordStat/Views/Home/Account.cshtml
@@ -5,9 +5,9 @@
 <ul>
 @foreach (var s in Model)
 {
-    <li>@s.owner</li>
-    <li>@s.name</li>
-    <li>@s.id</li>
+    <li>@s.Owner</li>
+    <li>@s.Name</li>
+    <li>@s.Id</li>
 
 }
 </ul>

--- a/sprint_1/ProjectDiscordStat/DiscordStats_Tests/DiscordService_Tests.cs
+++ b/sprint_1/ProjectDiscordStat/DiscordStats_Tests/DiscordService_Tests.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using DiscordStats.DAL.Concrete;
+using DiscordStats.Models;
+
+namespace DiscordStats_Tests
+{
+    public class DiscordService_Tests
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public void GetGuilds_ValidDataForTwoServersFromDiscord_ShouldParseOK()
+        {
+            // Arrange
+            DiscordService discord = new DiscordService();
+            // I didn't know what this was supposed to look like so I copied what I thought
+            // was the correct example from the Discord API docs.  Doesn't look right though as
+            // owner here is a bool but yours is a string.
+            string jsonFromDiscordAPI = @"[{
+  ""id"": 1035111022,
+  ""name"": ""1337 Krew"",
+  ""icon"": ""8342729096ea3675442027381ff50dfe"",
+  ""owner"": ""true"",
+  ""permissions"": ""36953089"",
+  ""features"": [""COMMUNITY"", ""NEWS""]
+},
+{
+  ""id"": 1345452453,
+  ""name"": ""Omicron Knew"",
+  ""icon"": ""8872722096ea3634442027381ff50dbc"",
+  ""owner"": ""true"",
+  ""permissions"": ""36953089"",
+  ""features"": [""GAMES"", ""IMAGES""]
+}]";
+            // Act
+            List<Server>? servers = discord.GetCurrentUserGuilds("fakeBearerToken", (bt, uri) => jsonFromDiscordAPI);
+
+            // Assert
+            Assert.Multiple(() =>
+                {
+                    Assert.That(servers!.Count, Is.EqualTo(2));
+                    Assert.That(servers[0].Id == 1035111022);
+                    Assert.That(servers[0].Name == "1337 Krew");
+                    Assert.That(servers[0].Owner == "true");
+                }
+            );
+        }
+
+        [Test]
+        public void GetGuilds_EmptyStringFromDiscord_ShouldThrowException()
+        {
+            Assert.Fail();
+        }
+
+        // And continue with tests
+    }
+}

--- a/sprint_1/ProjectDiscordStat/DiscordStats_Tests/DiscordStats_Tests.csproj
+++ b/sprint_1/ProjectDiscordStat/DiscordStats_Tests/DiscordStats_Tests.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq.Contrib.HttpClient" Version="1.3.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />

--- a/sprint_1/ProjectDiscordStat/DiscordStats_Tests/DiscordStats_Tests.csproj
+++ b/sprint_1/ProjectDiscordStat/DiscordStats_Tests/DiscordStats_Tests.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\DiscordStat\DiscordStats.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Refactoring of the code used by HomeController.Account() to access the Discord API.  There haven't been any merges into dev since I pulled the code so this should merge easily if you want to do that.  **But, I haven't run the app with these changes so it make be broken.** It builds fine and I didn't change any of the underlying code.  Maybe have Korbin fetch it (not pull!), build, run and manually test before accepting the PR. 